### PR TITLE
SN-0004 Autoset setting "popup enable"

### DIFF
--- a/src/main_app.cpp
+++ b/src/main_app.cpp
@@ -11,7 +11,8 @@ BEGIN_MESSAGE_MAP(CSerialNotifierApp, CWinAppEx)
 END_MESSAGE_MAP()
 
 
-CSerialNotifierApp::CSerialNotifierApp()
+CSerialNotifierApp::CSerialNotifierApp() :
+    _settings(true)
 {
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -26,7 +26,7 @@ class Settings
 
 public:
 
-    inline Settings():
+    inline Settings(const bool force_popup_enable = false):
         _module_name(TEXT("serial_notifier")),
         _autorun(HKEY_CURRENT_USER, TEXT("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run"), _module_name, false),
         _popup(HKEY_CURRENT_USER, _make_app_reg_path(), TEXT("popup_enable"), false),
@@ -40,6 +40,11 @@ public:
         _fill_property_from_registry(_system_popup0, REG_DWORD, true, false, _is_value_true);
         //_fill_property_from_registry(_system_popup1, REG_DWORD, true, false, _is_value_true);
         //_fill_property_from_registry(_system_popup2, REG_DWORD, false, true, _is_value_true);
+
+        if (force_popup_enable && _system_popup0.value && !TRegistry::is_path_valid(_popup.reg_section, _popup.reg_path))
+        {
+            popup(true);
+        }
     }
 
     inline bool autorun() const

--- a/tests/settings_tests.cpp
+++ b/tests/settings_tests.cpp
@@ -62,6 +62,11 @@ struct TestRegistry1 : public TestRegistry
         return false;
     }
 
+    inline static bool is_path_valid(const HKEY section, const TCHAR * path)
+    {
+        return false;
+    }
+
     inline static bool delete_key(const HKEY section, const TCHAR * path, const TCHAR * key)
     {
         (void)section;
@@ -127,11 +132,63 @@ struct TestRegistry2 : public TestRegistry
 
         return false;
     }
+
+    inline static bool is_path_valid(const HKEY section, const TCHAR * path)
+    {
+        return false;
+    }
 };
 
 bool TestRegistry2::flag1 = false;
 bool TestRegistry2::flag2 = false;
 bool TestRegistry2::flag3 = false;
+
+struct TestRegistry3 : public TestRegistry
+{
+    inline static bool get_key_value(const HKEY section, const TCHAR * path, const TCHAR * key, serial_notifier::RegistryValue & value)
+    {
+        (void)section;
+        (void)path;
+        if (!::lstrcmp(key, TEXT("serial_notifier")))
+        {
+            return false;
+        }
+        else if (!::lstrcmp(key, TEXT("popup_enable")))
+        {
+            return false;
+        }
+        else if (!::lstrcmp(key, TEXT("EnableBallonTip")))
+        {
+            value = serial_notifier::RegistryValue(UINT32(1));
+            return true;
+        }
+        return false;
+    }
+
+    inline static bool set_key_value(const HKEY section, const TCHAR * path, const TCHAR * key, const serial_notifier::RegistryValue & value)
+    {
+        (void)section;
+        (void)path;
+        (void)key;
+        (void)value;
+
+        return false;
+    }
+
+    inline static bool delete_key(const HKEY section, const TCHAR * path, const TCHAR * key)
+    {
+        (void)section;
+        (void)path;
+        (void)key;
+
+        return false;
+    }
+
+    inline static bool is_path_valid(const HKEY section, const TCHAR * path)
+    {
+        return false;
+    }
+};
 
 static CString make_app_path()
 {
@@ -178,4 +235,13 @@ TEST_CASE("Testing settings for all flags are false", "[settings]")
     REQUIRE(TestRegistry2::flag1);
     REQUIRE(TestRegistry2::flag2);
     REQUIRE(TestRegistry2::flag3);
+}
+
+TEST_CASE("Testing settings force popup setting up", "[settings]")
+{
+    serial_notifier::Settings<TestRegistry3> settings(true);
+
+    REQUIRE(settings.popup());
+    REQUIRE_FALSE(settings.autorun());
+    REQUIRE(settings.system_popup());
 }


### PR DESCRIPTION
Checking if app registry path is valid on app launch. If non-valid then app thing that it is first launch, so try to set up key "popup enable"